### PR TITLE
Remove Polyfill.io CDN

### DIFF
--- a/lib/Formatter/HtmlFormatter.php
+++ b/lib/Formatter/HtmlFormatter.php
@@ -120,8 +120,7 @@ class HtmlFormatter {
 
     private function getScriptsHtml()
     {
-        $html = '<script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>';
-        $html .= '<script>'.file_get_contents(__DIR__ . '/../../res/bliss.min.js').'</script>';
+        $html = '<script>' . file_get_contents(__DIR__ . '/../../res/bliss.min.js') . '</script>';
         $html .= '<script>'.file_get_contents(__DIR__.'/../../res/scripts.js').'</script>';
         return $html;
     }


### PR DESCRIPTION
Polyfill.io CDN has been blocked in many countries now due to malicious behaviour. On top of that most modern browsers no longer need polyfills as they've integreated the functionality polyfill was patching.